### PR TITLE
Avoid non documented exceptions in BinaryFormatter.Deserialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # dummy-repo
 dummy-repo
+more lines

--- a/StringBuilder.cs
+++ b/StringBuilder.cs
@@ -1,0 +1,1 @@
+mostly caring about file name not content

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.cs
@@ -1,0 +1,1 @@
+binary formatters


### PR DESCRIPTION
Fixes #35491. BinaryFormatter.Deserialize can throw other exceptions than those specified in the documentation (SerializationException, SecurityException & ArgumentNullException) in cases of corrupt input. This update changes the BinaryFormatter.Deserialize method to wrap those "internal" exception inside an SerializationException.