### PR TITLE
Avoid non documented exceptions in BinaryFormatter.Deserialize

### DIFF
--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.cs
@@ -1,0 +1,1 @@
+binary formatters


### PR DESCRIPTION
Fixes #35491. BinaryFormatter.Deserialize can throw other exceptions than those specified in the documentation (SerializationException, SecurityException & ArgumentNullException) in cases of corrupt input. This update changes the BinaryFormatter.Deserialize method to wrap those "internal" exception inside an SerializationException.