### PR TITLE
[release/3.0] Honor JsonIgnore attribute when applied to unsupported collections

### DIFF
--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.cs
@@ -1,0 +1,1 @@
+binary formatters


### PR DESCRIPTION
Ports dotnet corefx/pull/40401 to 3.0

cc steveharter, ericstj, danmosemsft, ahsonkhan eerhardt, Anipik, wtgodbe

## Description
Fixes bug where the JsonIgnore attribute was not being honored for unsupported collections.

This change allows us to (de)serialize without throwing NotSupported/JsonException when unsupported collections are ignored like in this scenario:

```csharp
class JsonIgnoreTest
{
    [JsonIgnore]
    public ConcurrentDictionary<object, object> MyDict { get; set; }
}
```

## Customer Impact
Provides expected behavior in scenario above.
Fixed #40305 in master.

## Regression?

No.

## Risk

Low. Relevant test cases were added.