### PR TITLE
Add FreeBSD terminfo location to well-known

### DIFF
--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.cs
@@ -1,0 +1,1 @@
+binary formatters


### PR DESCRIPTION
According to [terminfo(5)](https://www.freebsd.org/cgi/man.cgi?query=terminfo&sektion=5) on FreeBSD, this should be the well-known location for the terminfo database on the platform. Consequently, this is where ncurses looks for terminfo on FreeBSD.