### PR TITLE
[release/3.0] Fix UAF when removing trusted certs on OSX

### DIFF
--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.cs
@@ -1,0 +1,1 @@
+binary formatters


### PR DESCRIPTION
CheckTrustSettings called CFRelease on cert, which downref'd it to zero
before IsCertInKeychain ran.

Now CheckTrustSettings leaves cert alive, and it's the caller's responsibility to CFRelease.

Fixes #40491.