### PR TITLE
[release/3.0] Fix UAF when removing trusted certs on OSX

### DIFF
--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.cs
@@ -1,0 +1,1 @@
+binary formatters


### PR DESCRIPTION
Make MemberData reference IEnumerable<object[]>

Fixes #39697
cc: stephentoub